### PR TITLE
修复在 URL 中出现的 @ 也会自动变为 @ 用户 链接的问题

### DIFF
--- a/util/contentfmt.go
+++ b/util/contentfmt.go
@@ -14,7 +14,7 @@ var (
 	// codeRegexp    = regexp.MustCompile("(?s:```(.+?)```)")
 	// imgRegexp     = regexp.MustCompile(`(https?://[\w./:]+/[\w./]+\.(jpg|jpe|jpeg|gif|png))`)
 	gistRegexp    = regexp.MustCompile(`(https?://gist\.github\.com/([a-zA-Z0-9-]+/)?[\d]+)`)
-	mentionRegexp = regexp.MustCompile(`\B@([a-zA-Z0-9\p{Han}]{1,32})\s?`)
+	mentionRegexp = regexp.MustCompile(`(?:\s|^)@([a-zA-Z0-9\p{Han}]{1,32})\s?`)
 	// urlRegexp     = regexp.MustCompile(`([^;"='>])(https?://[^\s<]+[^\s<.)])`)
 	// nlineRegexp   = regexp.MustCompile(`\s{2,}`)
 	youku1Regexp  = regexp.MustCompile(`https?://player\.youku\.com/player\.php/sid/([a-zA-Z0-9=]+)/v\.swf`)


### PR DESCRIPTION
https://2049bbs.xyz/t/594

在 URL 中出现的 `@` 也会变为 @ 用户 的链接

原因是 `@`  字符前的 `/` 字符同样是 `\W` 字符集合的元素，因此不是单词边界
正则会匹配到
```
\b             at ASCII word boundary (\w on one side and \W, \A, or \z on the other)
\B             not at ASCII word boundary
```
(https://golang.org/pkg/regexp/syntax/)