### PR TITLE
禁用发帖时的自动填充功能 - fixes #43

### DIFF
--- a/view/default/desktop/adminarticleedit.html
+++ b/view/default/desktop/adminarticleedit.html
@@ -13,7 +13,7 @@
 
 <div class="main-box">
     <p><input id="id-title" type="text" name="title" value="{{.Aobj.Title}}" class="sll" /></p>
-    <p><textarea id="id-content" name="content" class="mll tall">{{.Aobj.Content}}</textarea></p>
+    <p><textarea id="id-content" name="content" class="mll tall" autocomplete="off">{{.Aobj.Content}}</textarea></p>
     <p><input id="id-tags" type="text" value="{{.Aobj.Tags}}" class="sll" /></p>
 
     <div class="float-right grey fs12">

--- a/view/default/desktop/admincommentedit.html
+++ b/view/default/desktop/admincommentedit.html
@@ -6,7 +6,7 @@
 </div>
 
 <div class="main-box">
-    <p><textarea id="id-content" name="content" class="mll tall">{{.Cobj.Content}}</textarea></p>
+    <p><textarea id="id-content" name="content" class="mll tall" autocomplete="off">{{.Cobj.Content}}</textarea></p>
 
     <div class="float-right grey fs12">
         <input id="file_upload" name="file_upload" type="file" multiple="true">

--- a/view/default/desktop/article.html
+++ b/view/default/desktop/article.html
@@ -147,7 +147,7 @@
 </div>
 <div class="main-box">
     <form action="#new-comment" method="POST" enctype="multipart/form-data">
-        <p><textarea id="id-content" name="content" class="comment-text mll"></textarea></p>
+        <p><textarea id="id-content" name="content" class="comment-text mll" autocomplete="off"></textarea></p>
 
         <p>
             <div class="float-left">

--- a/view/default/desktop/articlecreate.html
+++ b/view/default/desktop/articlecreate.html
@@ -13,7 +13,7 @@
 
 <div class="main-box">
     <p><input id="id-title" type="text" name="title" value="" class="sll" /></p>
-    <p><textarea id="id-content" name="content" class="mll tall"></textarea></p>
+    <p><textarea id="id-content" name="content" class="mll tall" autocomplete="off"></textarea></p>
 
    <!-- <div class="float-right grey fs12">
         <input id="file_upload" name="file_upload" type="file" multiple="true">

--- a/view/default/mobile/adminarticleedit.html
+++ b/view/default/mobile/adminarticleedit.html
@@ -13,7 +13,7 @@
 
 <div class="main-box">
     <p><input id="id-title" type="text" name="title" value="{{.Aobj.Title}}" class="sll wb96" /></p>
-    <p><textarea id="id-content" name="content" class="mll tall wb96">{{.Aobj.Content}}</textarea></p>
+    <p><textarea id="id-content" name="content" class="mll tall wb96" autocomplete="off">{{.Aobj.Content}}</textarea></p>
     <p><input id="id-tags" type="text" value="{{.Aobj.Tags}}" class="sll wb96" /></p>
 
     <div class="float-right grey fs12">

--- a/view/default/mobile/admincommentedit.html
+++ b/view/default/mobile/admincommentedit.html
@@ -6,7 +6,7 @@
 </div>
 
 <div class="main-box">
-    <p><textarea id="id-content" name="content" class="mll tall wb96">{{.Cobj.Content}}</textarea></p>
+    <p><textarea id="id-content" name="content" class="mll tall wb96" autocomplete="off">{{.Cobj.Content}}</textarea></p>
 
     <div class="float-right grey fs12">
         <input id="file_upload" name="file_upload" type="file" multiple="true">

--- a/view/default/mobile/article.html
+++ b/view/default/mobile/article.html
@@ -146,7 +146,7 @@
 </div>
 <div class="main-box">
     <form action="#new-comment" method="POST" enctype="multipart/form-data">
-        <p><textarea id="id-content" name="content" class="comment-text mll wb96"></textarea></p>
+        <p><textarea id="id-content" name="content" class="comment-text mll wb96" autocomplete="off"></textarea></p>
 
         <p>
             <div class="float-left">

--- a/view/default/mobile/articlecreate.html
+++ b/view/default/mobile/articlecreate.html
@@ -13,7 +13,7 @@
 
 <div class="main-box">
     <p><input id="id-title" type="text" name="title" value="" class="sll wb96" /></p>
-    <p><textarea id="id-content" name="content" class="mll tall wb96"></textarea></p>
+    <p><textarea id="id-content" name="content" class="mll tall wb96" autocomplete="off"></textarea></p>
 
     <!-- <div class="float-right grey fs12">
         <input id="file_upload" name="file_upload" type="file" multiple="true">


### PR DESCRIPTION
将 `<textarea>` 标签的 `autocomplete ` 属性设置为 `off`，关闭浏览器的记忆功能自动填充文本  
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-autocomplete

Fixes #43 
